### PR TITLE
Escape HTML in controllers

### DIFF
--- a/app/controllers/Codebare.php
+++ b/app/controllers/Codebare.php
@@ -8,12 +8,13 @@
 		//test_ean13.php
 		public function getCodebare() {
 			// barecode/code/test_code128.php?text=123456789
-			if(isset($_GET['text']) && !empty($_GET['text']) && strlen($_GET['text'])){
-				// $text = '/packbarecode/code/test_code128.php?text='.trim($_GET['text']);
-				$text = '/packbarecode/code/test_ean13.php?text='.trim($_GET['text']);
-				$this->view = str_replace("{{image}}",$text, $this->view);
-				echo $this->view;
-			}
+if(isset($_GET['text']) && !empty($_GET['text']) && strlen($_GET['text'])){
+// $text = '/packbarecode/code/test_code128.php?text='.trim($_GET['text']);
+$safeText = htmlspecialchars(trim($_GET['text']), ENT_QUOTES, 'UTF-8');
+$text = '/packbarecode/code/test_ean13.php?text='.$safeText;
+$this->view = str_replace("{{image}}",$text, $this->view);
+echo $this->view;
+}
 			die();
 		}
 		

--- a/app/controllers/GlpiController.php
+++ b/app/controllers/GlpiController.php
@@ -150,19 +150,19 @@
 			foreach ($rows as $item) {
 					$content .= "<tr>";
 					foreach ($item as $key => $value) {
-						if($key==='user_dn' && $value != '') {
-							// $content .= "<td>".($value??'<em class="null">null</em>')."</td>";
-							$string = explode(",", $value);
-							$paquet = substr($string[1],3);
-							$section = substr($paquet, 0,-4);
-							$section = str_replace("BTS", "", $section);
-							$promo = substr($paquet, -4);
-							$content .= "<td>".$section."</td>";
-							$content .= "<td>".$promo."</td>";
-						}
-						else {
-							$content .= "<td>".($value??'<em class="null">null</em>')."</td>";
-						}
+                                            if($key==='user_dn' && $value != '') {
+                                                    // $content .= "<td>".($value??'<em class=\"null\">null</em>')."</td>";
+                                                    $string = explode(',', $value);
+                                                    $paquet = substr($string[1],3);
+                                                    $section = substr($paquet, 0,-4);
+                                                    $section = str_replace("BTS", "", $section);
+                                                    $promo = substr($paquet, -4);
+                                                    $content .= "<td>".htmlspecialchars($section, ENT_QUOTES, 'UTF-8')."</td>";
+                                                    $content .= "<td>".htmlspecialchars($promo, ENT_QUOTES, 'UTF-8')."</td>";
+                                            }
+                                            else {
+                                                    $content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
+                                            }
 						
 					}
 

--- a/app/controllers/InController.php
+++ b/app/controllers/InController.php
@@ -59,19 +59,19 @@
 
 					
 					if($lpd && count($lpd)> 0){
-						$this->messagepc .= "<div>Pc N°".$lpd[0]['idpc']." loué le: ".$lpd[0]['birth']."</div>";
-						$this->messagepc .= "<div>Model:".$this->pc['model']."</div>";
-						$this->messagepc .= "<div>état: ".$this->pc['etat']."</div>";
-						$this->messagepc .= "<div>Par ideleve: ".$lpd[0]['ideleves']."</div>";
+$this->messagepc .= "<div>Pc N°".htmlspecialchars($lpd[0]['idpc'], ENT_QUOTES, 'UTF-8')." loué le: ".htmlspecialchars($lpd[0]['birth'], ENT_QUOTES, 'UTF-8')."</div>";
+$this->messagepc .= "<div>Model:".htmlspecialchars($this->pc['model'], ENT_QUOTES, 'UTF-8')."</div>";
+$this->messagepc .= "<div>état: ".htmlspecialchars($this->pc['etat'], ENT_QUOTES, 'UTF-8')."</div>";
+$this->messagepc .= "<div>Par ideleve: ".htmlspecialchars($lpd[0]['ideleves'], ENT_QUOTES, 'UTF-8')."</div>";
 
 						// qui était locataire by id
 						$this->lastClientDatas = $this->getClientById($lpd[0]['ideleves']) ;
 						$lcd = $this->lastClientDatas;
 						if($lpd && count($lpd)> 0){
-							$this->messagepc .= "<div>lastClientDatas: ".$lcd[0]['id']."</div> ";
-							$this->messagepc .= "<div>nom prenom: ".$lcd[0]['nom']." ".$lcd[0]['prenom']."</div>";
-							$this->messagepc .= "<div>[".$lcd[0]['classe']."</div> ";
-							$this->messagepc .= "<div>".$lcd[0]['promo']."]</div>";
+$this->messagepc .= "<div>lastClientDatas: ".htmlspecialchars($lcd[0]['id'], ENT_QUOTES, 'UTF-8')."</div> ";
+$this->messagepc .= "<div>nom prenom: ".htmlspecialchars($lcd[0]['nom'], ENT_QUOTES, 'UTF-8')." ".htmlspecialchars($lcd[0]['prenom'], ENT_QUOTES, 'UTF-8')."</div>";
+$this->messagepc .= "<div>[".htmlspecialchars($lcd[0]['classe'], ENT_QUOTES, 'UTF-8')."</div> ";
+$this->messagepc .= "<div>".htmlspecialchars($lcd[0]['promo'], ENT_QUOTES, 'UTF-8')."]</div>";
 							$this->messagepc .= '<img src="/vendor/feunico/svg/profile.svg" style="width:100px">';
 						}
 
@@ -231,10 +231,10 @@
 			
 			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
-				if($this->pc){
-					$html = str_replace('{{msgpc}}', $this->messagepc, $html);
-					$html = str_replace('{{pcbarrecode}}', $this->pc['barrecode'], $html);
-				}
+if($this->pc){
+$html = str_replace('{{msgpc}}', $this->messagepc, $html);
+$html = str_replace('{{pcbarrecode}}', htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
+}
 				else {
 					$html = str_replace('{{pcbarrecode}}', '', $html);
 					$html = str_replace('{{msgpc}}', '', $html);

--- a/app/controllers/ListingController.php
+++ b/app/controllers/ListingController.php
@@ -66,11 +66,11 @@
 			else {
 				$content = '';
 				foreach ($items as $item) {
-						$content .= '<tr id="row_'.$item['id'].'">';
+						$content .= '<tr id="row_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'">';
 						foreach ($item as $value) {
-							$content .= "<td>".($value??'<em class="null">null</em>')."</td>";
+							$content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
 						}
-						if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.$item['id'].'" name="item_'.$item['id'].'" checked /></td>';
+						if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" name="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" checked /></td>';
 					$content .= "</tr>";
 				}
 				
@@ -144,14 +144,14 @@
 
 			$items = $this->getRowsFrom('eleves',implode(",", $sqlList));
 
-			$content = '';			
+			$content = '';
 			foreach ($items as $item) {
-					$content .= "<tr>";
-					$content .= '<td><input type="checkbox" id="item_'.$item['id'].'" name="item_'.$item['id'].'" /></td>';
-					foreach ($item as $value) {
-						$content .= "<td>".($value??'<em class="null">null</em>')."</td>";
-					}
-					$content .= '<td><a href="/eleve?num='.$item['id'].'">ref: '.$item['id'].'</a></td>';
+				$content .= "<tr>";
+				$content .= '<td><input type="checkbox" id="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" name="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" /></td>';
+				foreach ($item as $value) {
+					$content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
+				}
+				$content .= '<td><a href="/eleve?num='.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'">ref: '.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'</a></td>';
 				$content .= "</tr>";
 			}
 			
@@ -194,7 +194,7 @@
 			foreach ($items as $item) {
 					$content .= "<tr>";
 					foreach ($item as $value) {
-						$content .= "<td>".$value."</td>";
+						$content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class="null">null</em>')."</td>";
 					}
 				$content .= "</tr>";
 			}

--- a/app/controllers/OutController.php
+++ b/app/controllers/OutController.php
@@ -130,21 +130,21 @@
 	
 			
 			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-				if($this->eleve){
-					$messageeleve .= $this->eleve['barrecode'];
-					$html = str_replace('{{msgeleve}}', $this->eleve['prenom']." ".$this->eleve['nom']."<br>", $html);
-					$html = str_replace('{{elevebarrecode}}', $this->eleve['barrecode'], $html);
-				}
+if($this->eleve){
+$messageeleve .= htmlspecialchars($this->eleve['barrecode'], ENT_QUOTES, 'UTF-8');
+$html = str_replace('{{msgeleve}}', htmlspecialchars($this->eleve['prenom'], ENT_QUOTES, 'UTF-8')." ".htmlspecialchars($this->eleve['nom'], ENT_QUOTES, 'UTF-8')."<br>", $html);
+$html = str_replace('{{elevebarrecode}}', htmlspecialchars($this->eleve['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
+}
 				else {
 					$html = str_replace('{{elevebarrecode}}', '', $html);
 					$html = str_replace('{{msgeleve}}', '', $html);
 				}
 
-				if($this->pc){
-					$messagepc .= $this->pc['barrecode'];
-					$html = str_replace('{{msgpc}}', $this->pc['barrecode'], $html);
-					$html = str_replace('{{pcbarrecode}}', $this->pc['barrecode'], $html);
-				}
+if($this->pc){
+$messagepc .= htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8');
+$html = str_replace('{{msgpc}}', htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
+$html = str_replace('{{pcbarrecode}}', htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
+}
 				else {
 					$html = str_replace('{{pcbarrecode}}', '', $html);
 					$html = str_replace('{{msgpc}}', '', $html);

--- a/app/controllers/ProfileController.php
+++ b/app/controllers/ProfileController.php
@@ -1,79 +1,79 @@
 <?php
-	namespace app\controllers;
+        namespace app\controllers;
 
-	class ProfileController
-	{
-		private $view = '';
+        class ProfileController
+        {
+                private $view = '';
 
-		private $pdo;
-		private $CheckDb;
-		private $contents = [
-			'TITLE'=> 'Page Profil',
-			'CONTENT'=> ''
-		];
+                private $pdo;
+                private $CheckDb;
+                private $contents = [
+                        'TITLE'=> 'Page Profil',
+                        'CONTENT'=> ''
+                ];
 
-		public function __construct($CheckDb) {
-			if($CheckDb){
-				$this->CheckDb = $CheckDb;
-			}
-			$this->view = file_get_contents('../app/views/profile.php');
-		}
-		
-		public function showProfile()
-		{
-			$this->pdo = $this->CheckDb->getPdo();
-			if (!isset($_SESSION['user'])) {
-				header('Location: /login');
-			} else {
+                public function __construct($CheckDb) {
+                        if($CheckDb){
+                                $this->CheckDb = $CheckDb;
+                        }
+                        $this->view = file_get_contents('../app/views/profile.php');
+                }
 
-				$content = str_replace("{{TITLE}}",$this->contents['TITLE'],$this->view);
-				$profileHtml = 'une erreur sans doute ?';
-				$row = $this->getProfilRow();
-				if ($row && count($row) > 0){
-					$profileHtml = "
-					<div class=\"form-container\">
-					<h3>".$_SESSION['user']['pseudo']."</h3>
-						<p>Pseudo: ".$row['pseudo']."</p>
-						<p>Nom: ".$_SESSION['user']['nom']."</p>
-						<p>Prénom: ".$_SESSION['user']['prenom']."</p>
-						<p>account: ".$_SESSION['user']['typeaccount']." (lv:".$_SESSION['user']['typeaccount_id'].")</p>
-						<p>Création: ".$row['birth']."</p>
-						<p>mail: <a href=". '"mailto:' .$row['mail'].'"'.">M'envoyer un mail ?</a></p>
-					</div>";
-				}
+                public function showProfile()
+                {
+                        $this->pdo = $this->CheckDb->getPdo();
+                        if (!isset($_SESSION['user'])) {
+                                header('Location: /login');
+                        } else {
 
-
-				$content = str_replace("{{CONTENT}}",$profileHtml, $content);
+                                $content = str_replace("{{TITLE}}",$this->contents['TITLE'],$this->view);
+                                $profileHtml = 'une erreur sans doute ?';
+                                $row = $this->getProfilRow();
+                                if ($row && count($row) > 0){
+                                        $profileHtml = "
+                                        <div class=\"form-container\">
+                                        <h3>".htmlspecialchars($_SESSION['user']['pseudo'], ENT_QUOTES, 'UTF-8')."</h3>
+                                                <p>Pseudo: ".htmlspecialchars($row['pseudo'], ENT_QUOTES, 'UTF-8')."</p>
+                                                <p>Nom: ".htmlspecialchars($_SESSION['user']['nom'], ENT_QUOTES, 'UTF-8')."</p>
+                                                <p>Prénom: ".htmlspecialchars($_SESSION['user']['prenom'], ENT_QUOTES, 'UTF-8')."</p>
+                                                <p>account: ".htmlspecialchars($_SESSION['user']['typeaccount'], ENT_QUOTES, 'UTF-8')." (lv:".htmlspecialchars($_SESSION['user']['typeaccount_id'], ENT_QUOTES, 'UTF-8').")</p>
+                                                <p>Création: ".htmlspecialchars($row['birth'], ENT_QUOTES, 'UTF-8')."</p>
+                                                <p>mail: <a href=\"mailto:".htmlspecialchars($row['mail'], ENT_QUOTES, 'UTF-8')."\">M'envoyer un mail ?</a></p>
+                                        </div>";
+                                }
 
 
+                                $content = str_replace("{{CONTENT}}",$profileHtml, $content);
 
-				$this->contents['CONTENT'] = $content;
-				return $this->contents;
-			}
-		}
-		private function  getProfilRow(){
-			if(!$this->pdo) return false;
-			try{
-				$id = $_SESSION['user']['id'];
-				$sessionkey = $_SESSION['user']['sessionkey'];
-				$select = 'pseudo, nom, prenom, birth, mail';
-				$query = "SELECT ".$select." FROM administrateurs WHERE id = :id AND sessionkey = :sessionkey LIMIT 1";
-				
-				$stmt = $this->pdo->prepare($query);
-				$stmt->bindParam(':id', $id, \PDO::PARAM_INT);
-				$stmt->bindParam(':sessionkey', $sessionkey, \PDO::PARAM_STR);
-				$stmt->execute();
-				$row = $stmt->fetch(\PDO::FETCH_ASSOC);
-				if ($row && count($row) > 0){
-					// on a une réponse
-					return $row;
-				}
-			} 
-			catch (\PDOException $e) {
-				die("getProfilRow : Erreur de connexion à la base de données : " . $e->getMessage());
-			} catch (\Exception $e) {
-				die("getProfilRow : Erreur de deconnexion : " . $e->getMessage());
-			}
-			return false;
-		}
-	}
+
+
+                                $this->contents['CONTENT'] = $content;
+                                return $this->contents;
+                        }
+                }
+                private function  getProfilRow(){
+                        if(!$this->pdo) return false;
+                        try{
+                                $id = $_SESSION['user']['id'];
+                                $sessionkey = $_SESSION['user']['sessionkey'];
+                                $select = 'pseudo, nom, prenom, birth, mail';
+                                $query = "SELECT ".$select." FROM administrateurs WHERE id = :id AND sessionkey = :sessionkey LIMIT 1";
+
+                                $stmt = $this->pdo->prepare($query);
+                                $stmt->bindParam(':id', $id, \PDO::PARAM_INT);
+                                $stmt->bindParam(':sessionkey', $sessionkey, \PDO::PARAM_STR);
+                                $stmt->execute();
+                                $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+                                if ($row && count($row) > 0){
+                                        // on a une réponse
+                                        return $row;
+                                }
+                        }
+                        catch (\PDOException $e) {
+                                die("getProfilRow : Erreur de connexion à la base de données : " . $e->getMessage());
+                        } catch (\Exception $e) {
+                                die("getProfilRow : Erreur de deconnexion : " . $e->getMessage());
+                        }
+                        return false;
+                }
+        }

--- a/app/controllers/ThreeController.php
+++ b/app/controllers/ThreeController.php
@@ -45,8 +45,8 @@
 			
 			// $htmlView = str_replace('{{TITLE}}', $this->content['TITLE'], $htmlView);
 			// $htmlView = str_replace('{{CONTENT}}', $this->content['CONTENT'], $htmlView);
-			$htmlView = str_replace('{{pcsJson}}', $this->pcsJson, $htmlView);
-			$htmlView = str_replace('{{timelineJson}}', $this->timelineJson, $htmlView);
+$htmlView = str_replace('{{pcsJson}}', htmlspecialchars($this->pcsJson, ENT_QUOTES, 'UTF-8'), $htmlView);
+$htmlView = str_replace('{{timelineJson}}', htmlspecialchars($this->timelineJson, ENT_QUOTES, 'UTF-8'), $htmlView);
 
 			$this->content['CONTENT'] = $htmlView;
 


### PR DESCRIPTION
## Summary
- Escape values in listing views to prevent injection
- Sanitize user and asset data before rendering profile, in/out, and GLPI views
- Clean up barcode and three controllers with HTML escaping

## Testing
- `php -l app/controllers/ListingController.php && php -l app/controllers/ProfileController.php && php -l app/controllers/InController.php && php -l app/controllers/OutController.php && php -l app/controllers/GlpiController.php && php -l app/controllers/Codebare.php && php -l app/controllers/ThreeController.php`

------
https://chatgpt.com/codex/tasks/task_e_68b6cba200d88329bed2e289c45a7fbf