### PR TITLE
Add CSRF protection to asset in/out actions

### DIFF
--- a/app/controllers/InController.php
+++ b/app/controllers/InController.php
@@ -29,25 +29,29 @@
 			$this->messages = [];
 			
 
-			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-				$this->pc = null;
+                        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                                $token = $_POST['csrf_token'] ?? '';
+                                if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+                                        $this->messages[]=["content"=>"Token CSRF invalide","result"=>"error"];
+                                } else {
+                                        $this->pc = null;
 
-				if (!empty($_POST['pc'])){
-					$assetBarrecode = $_POST['pc'] ?? '';
-					$assetBarrecode = filter_var($assetBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-					if (!empty($assetBarrecode)) {
-						// recherche du barrecode dans eleve
-						$row = $this->CheckDb->once('pc',$assetBarrecode);
-						if(count($row)===1) {
-							$this->pc = $row[0];
-						}
-						else {
-							$this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"error"];
-						}
-					}
-				}
+                                        if (!empty($_POST['pc'])){
+                                                $assetBarrecode = $_POST['pc'] ?? '';
+                                                $assetBarrecode = filter_var($assetBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+                                                if (!empty($assetBarrecode)) {
+                                                        // recherche du barrecode dans eleve
+                                                        $row = $this->CheckDb->once('pc',$assetBarrecode);
+                                                        if(count($row)===1) {
+                                                                $this->pc = $row[0];
+                                                        }
+                                                        else {
+                                                                $this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"error"];
+                                                        }
+                                                }
+                                        }
 
-				if($this->pc){
+                                        if($this->pc){
 
 
 					// qui a réservé ce pc dans la derniere action ?
@@ -89,14 +93,15 @@ $this->messagepc .= "<div>".htmlspecialchars($lcd[0]['promo'], ENT_QUOTES, 'UTF-
 						: ["content"=>"ENREGISTREMENT Raté  !","result"=>"alerte"];
 
 					$id = $last[0]['id'] ?? '';				
-					$this->contents['Redirect'] = [
-						'url'=> '/in?last='.$id,
-						'refresh'=> CONFIG['REFRESH']['in']
-					];
-				}
-			}
+                                        $this->contents['Redirect'] = [
+                                                'url'=> '/in?last='.$id,
+                                                'refresh'=> CONFIG['REFRESH']['in']
+                                        ];
+                                }
+                        }
+                        }
 
-			$html = $this->renderView();
+                        $html = $this->renderView();
 			
 			$this->contents = [
 				'CONTENT'=> $html,
@@ -209,8 +214,9 @@ $this->messagepc .= "<div>".htmlspecialchars($lcd[0]['promo'], ENT_QUOTES, 'UTF-
 
 		// Afficher la vue login avec les erreurs
 		private function renderView(): string {
-			$html = file_get_contents(filename: '../app/views/in.php');
-			$messageeleve = "";
+                        $html = file_get_contents(filename: '../app/views/in.php');
+                        $html = str_replace('{{csrf_token}}', htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'), $html);
+                        $messageeleve = "";
 
 
 

--- a/app/controllers/OutController.php
+++ b/app/controllers/OutController.php
@@ -24,46 +24,51 @@
 				}
 			}
 
-			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-				$this->eleve = null;
-				$this->pc = null;
+                        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                                $token = $_POST['csrf_token'] ?? '';
+                                if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+                                        $this->messages[] = ["content"=>"Token CSRF invalide","result"=>"error"];
+                                } else {
+                                        $this->eleve = null;
+                                        $this->pc = null;
 
-				if (!empty($_POST['eleve'])){
-					$memberBarrecode = isset($_POST['eleve']) ? trim($_POST['eleve']) : '';
-					$memberBarrecode = filter_var($memberBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-					if (!empty($memberBarrecode)) {
-						// recherche du barrecode dans eleve
-						$row = $this->CheckDb->once('eleves',$memberBarrecode);
-						if(count($row)===1) {
-							$this->eleve = $row[0];
-						}
-						else {
-							$this->messages[]=["content"=>"BarreCode élève introuvable !","result"=>"error"];
-						}
-					}
-				}
-				if (!empty($_POST['pc'])){
-					$assetBarrecode = $_POST['pc'] ?? '';
-					$assetBarrecode = filter_var($assetBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-					if (!empty($assetBarrecode)) {
-						// recherche du barrecode dans eleve
-						$row = $this->CheckDb->once('pc',$assetBarrecode);
-						if(count($row)===1) {
-							$this->pc = $row[0];
-						}
-						else {
-							$this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"alerte"];
-						}
-					}
-				}
+                                        if (!empty($_POST['eleve'])){
+                                                $memberBarrecode = isset($_POST['eleve']) ? trim($_POST['eleve']) : '';
+                                                $memberBarrecode = filter_var($memberBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+                                                if (!empty($memberBarrecode)) {
+                                                        // recherche du barrecode dans eleve
+                                                        $row = $this->CheckDb->once('eleves',$memberBarrecode);
+                                                        if(count($row)===1) {
+                                                                $this->eleve = $row[0];
+                                                        }
+                                                        else {
+                                                                $this->messages[]=["content"=>"BarreCode élève introuvable !","result"=>"error"];
+                                                        }
+                                                }
+                                        }
+                                        if (!empty($_POST['pc'])){
+                                                $assetBarrecode = $_POST['pc'] ?? '';
+                                                $assetBarrecode = filter_var($assetBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+                                                if (!empty($assetBarrecode)) {
+                                                        // recherche du barrecode dans eleve
+                                                        $row = $this->CheckDb->once('pc',$assetBarrecode);
+                                                        if(count($row)===1) {
+                                                                $this->pc = $row[0];
+                                                        }
+                                                        else {
+                                                                $this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"alerte"];
+                                                        }
+                                                }
+                                        }
 
-				if($this->pc && $this->eleve ){
-					$insertRespons = $this->insertTimelineOut($this->pc['id'], $this->eleve['id'], 'out') ;
-					$this->messages[] = $insertRespons
-						?["content"=>"ENREGISTREMENT OK !","result"=>"succes"]
-						:["content"=>"ENREGISTREMENT Raté  !","result"=>"succes"];
-				}
-			}
+                                        if($this->pc && $this->eleve ){
+                                                $insertRespons = $this->insertTimelineOut($this->pc['id'], $this->eleve['id'], 'out') ;
+                                                $this->messages[] = $insertRespons
+                                                        ?["content"=>"ENREGISTREMENT OK !","result"=>"succes"]
+                                                        :["content"=>"ENREGISTREMENT Raté  !","result"=>"succes"];
+                                        }
+                                }
+                        }
 			if($this->pc && $this->eleve ){
 				$html = $this->renderView();
 				
@@ -123,8 +128,9 @@
 	
 		// Afficher la vue login avec les erreurs
 		private function renderView(): string {
-			$html = file_get_contents(filename: '../app/views/out.php');
-			$messageeleve = "";
+                        $html = file_get_contents(filename: '../app/views/out.php');
+                        $html = str_replace('{{csrf_token}}', htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'), $html);
+                        $messageeleve = "";
 			$messagepc = "";
 			$messages = '';			
 	

--- a/app/views/in.php
+++ b/app/views/in.php
@@ -1,8 +1,9 @@
 	<h1>Rendez un Pc !</h1>
 	<div class="form-container">
-		<form method="POST" action="in">
-			{{errors}}
-			<div class="blocs">
+                <form method="POST" action="in">
+                        {{errors}}
+                        <input type="hidden" name="csrf_token" value="{{csrf_token}}">
+                        <div class="blocs">
 				<div class="cards">
 					<div>
 						{{msgpc}}

--- a/app/views/out.php
+++ b/app/views/out.php
@@ -1,8 +1,9 @@
 	<h1>Empruntez un Pc !</h1>
 	<div class="form-container">
-		<form method="POST" action="out">
-			{{errors}}
-			<div class="blocs">
+                <form method="POST" action="out">
+                        {{errors}}
+                        <input type="hidden" name="csrf_token" value="{{csrf_token}}">
+                        <div class="blocs">
 			{{msgeleve}}
 				<svg id="barcodeEleve"></svg>
 				<div class="input-container">

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,9 @@
 <?php
-	session_start();
-	require_once '../app/core/autoloader.php';
+        session_start();
+        if (empty($_SESSION['csrf_token'])) {
+                $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+        require_once '../app/core/autoloader.php';
 
 	use app\core\console;
 	use app\core\checkdb;


### PR DESCRIPTION
## Summary
- generate session CSRF token
- embed CSRF token in in/out forms and validate on submit

## Testing
- `php -l public/index.php`
- `php -l app/controllers/OutController.php`
- `php -l app/controllers/InController.php`
- `php -l app/views/out.php`
- `php -l app/views/in.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d3acd91c8329a75759f7541045b1