### PR TITLE
Add validation for table names in CheckDb::once

### DIFF
--- a/app/controllers/InController.php
+++ b/app/controllers/InController.php
@@ -41,13 +41,16 @@
                                                 $assetBarrecode = filter_var($assetBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
                                                 if (!empty($assetBarrecode)) {
                                                         // recherche du barrecode dans eleve
-                                                        $row = $this->CheckDb->once('pc',$assetBarrecode);
-                                                        if(count($row)===1) {
-                                                                $this->pc = $row[0];
-                                                        }
-                                                        else {
-                                                                $this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"error"];
-                                                        }
+                                                       $row = $this->CheckDb->once('pc',$assetBarrecode);
+                                                       if(isset($row['error'])) {
+                                                               $this->messages[]=["content"=>$row['error'],"result"=>"error"];
+                                                       }
+                                                       elseif(count($row)===1) {
+                                                               $this->pc = $row[0];
+                                                       }
+                                                       else {
+                                                               $this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"error"];
+                                                       }
                                                 }
                                         }
 

--- a/app/controllers/OutController.php
+++ b/app/controllers/OutController.php
@@ -37,13 +37,16 @@
                                                 $memberBarrecode = filter_var($memberBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
                                                 if (!empty($memberBarrecode)) {
                                                         // recherche du barrecode dans eleve
-                                                        $row = $this->CheckDb->once('eleves',$memberBarrecode);
-                                                        if(count($row)===1) {
-                                                                $this->eleve = $row[0];
-                                                        }
-                                                        else {
-                                                                $this->messages[]=["content"=>"BarreCode élève introuvable !","result"=>"error"];
-                                                        }
+                                                       $row = $this->CheckDb->once('eleves',$memberBarrecode);
+                                                       if(isset($row['error'])) {
+                                                               $this->messages[]=["content"=>$row['error'],"result"=>"error"];
+                                                       }
+                                                       elseif(count($row)===1) {
+                                                               $this->eleve = $row[0];
+                                                       }
+                                                       else {
+                                                               $this->messages[]=["content"=>"BarreCode élève introuvable !","result"=>"error"];
+                                                       }
                                                 }
                                         }
                                         if (!empty($_POST['pc'])){
@@ -51,13 +54,16 @@
                                                 $assetBarrecode = filter_var($assetBarrecode, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
                                                 if (!empty($assetBarrecode)) {
                                                         // recherche du barrecode dans eleve
-                                                        $row = $this->CheckDb->once('pc',$assetBarrecode);
-                                                        if(count($row)===1) {
-                                                                $this->pc = $row[0];
-                                                        }
-                                                        else {
-                                                                $this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"alerte"];
-                                                        }
+                                                       $row = $this->CheckDb->once('pc',$assetBarrecode);
+                                                       if(isset($row['error'])) {
+                                                               $this->messages[]=["content"=>$row['error'],"result"=>"error"];
+                                                       }
+                                                       elseif(count($row)===1) {
+                                                               $this->pc = $row[0];
+                                                       }
+                                                       else {
+                                                               $this->messages[]=["content"=>"BarreCode PC introuvable !","result"=>"alerte"];
+                                                       }
                                                 }
                                         }
 

--- a/app/core/checkdb.php
+++ b/app/core/checkdb.php
@@ -95,26 +95,30 @@ class CheckDb
 		return $dberror;
 	}
 
-	/**
-	 * Fonction pour avoir une seule réponse
-	 */
-	public function once($table=false, $barrecode=false): array{
-		$respons = [];
-		if($table && $barrecode){
-			try {
-				$query = "SELECT * FROM {$table} WHERE barrecode = :barrecode LIMIT 1";
-				$stmt = $this->pdo->prepare($query);
-				$stmt->bindParam(':barrecode', $barrecode, \PDO::PARAM_STR);
-				$stmt->execute();
-				$respons = $stmt->fetchAll(\PDO::FETCH_ASSOC);
-			} catch (\PDOException $e) {
-				die("Erreur de connexion ou de création de la base de données : " . $e->getMessage());
-			} catch (\Exception $e) {
-				die("Erreur : " . $e->getMessage());
-			}
-		}
-		return $respons;
-	}
+       /**
+        * Fonction pour avoir une seule réponse
+        */
+       public function once($table=false, $barrecode=false): array{
+               $respons = [];
+               $allowedTables = ['pc','eleves','timeline'];
+               if($table && !in_array($table, $allowedTables, true)){
+                       return ['error'=>'table non autorisée'];
+               }
+               if($table && $barrecode){
+                       try {
+                               $query = "SELECT * FROM {$table} WHERE barrecode = :barrecode LIMIT 1";
+                               $stmt = $this->pdo->prepare($query);
+                               $stmt->bindParam(':barrecode', $barrecode, \PDO::PARAM_STR);
+                               $stmt->execute();
+                               $respons = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+                       } catch (\PDOException $e) {
+                               die("Erreur de connexion ou de création de la base de données : " . $e->getMessage());
+                       } catch (\Exception $e) {
+                               die("Erreur : " . $e->getMessage());
+                       }
+               }
+               return $respons;
+       }
 	
 	/**
 	 * Fonction pour mettre la position d'un pc a jour (in ou out)


### PR DESCRIPTION
## Summary
- restrict `CheckDb::once` to allowed tables and return error on invalid table
- handle invalid table responses in `InController` and `OutController`

## Testing
- `php -l app/core/checkdb.php`
- `php -l app/controllers/InController.php`
- `php -l app/controllers/OutController.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9a6f0ec8329ad3963fdfae2d456