### PR TITLE
feat: centralize view rendering

### DIFF
--- a/app/controllers/GlpiController.php
+++ b/app/controllers/GlpiController.php
@@ -1,7 +1,9 @@
 <?php
-	namespace app\controllers;
-	
-	class GlpiController {
+        namespace app\controllers;
+
+        use app\core\View;
+
+        class GlpiController {
 		private $lvAuth = 5;
 		private $pdfAuth;
 		private $CheckDb;
@@ -110,19 +112,14 @@
 			return $this->content;
 		}
 		
-		private function renderView(){
-			$htmlView = file_get_contents(filename: '../app/views/glpipc.php');
-				
-			$htmlView = str_replace('{{TITLE}}', $this->content['TITLE'], $htmlView);
-			$htmlView = str_replace('{{CONTENT}}', $this->content['CONTENT'], $htmlView);
-			// $htmlView = str_replace('{{FORMACTION}}', ' action="listpc"', $htmlView);
-			$htmlView = str_replace('{{PRINTINPUT}}', '', $htmlView);
+                private function renderView(){
+                        $this->content['CONTENT'] = View::render('glpipc.php', [
+                                'TITLE' => $this->content['TITLE'],
+                                'CONTENT' => $this->content['CONTENT'],
+                                'PRINTINPUT' => ''
+                        ]);
 
-
-
-			$this->content['CONTENT'] = $htmlView;
-
-		}
+                }
 		private function getTheadersAndCols($titles=[]) {
 			$cols = [];
 			$theaders = "<tr>";
@@ -144,61 +141,59 @@
 		private function getList($title, $table, $theaders=false, $rows=[], $categorie) {
 
 
-			$html = file_get_contents('../app/views/glpipc/listesGlpi.php');
-			$content = '';
+                        $content = '';
 
-			foreach ($rows as $item) {
-					$content .= "<tr>";
-					foreach ($item as $key => $value) {
-                                            if($key==='user_dn' && $value != '') {
-                                                    // $content .= "<td>".($value??'<em class=\"null\">null</em>')."</td>";
-                                                    $string = explode(',', $value);
-                                                    $paquet = substr($string[1],3);
-                                                    $section = substr($paquet, 0,-4);
-                                                    $section = str_replace("BTS", "", $section);
-                                                    $promo = substr($paquet, -4);
-                                                    $content .= "<td>".htmlspecialchars($section, ENT_QUOTES, 'UTF-8')."</td>";
-                                                    $content .= "<td>".htmlspecialchars($promo, ENT_QUOTES, 'UTF-8')."</td>";
-                                            }
-                                            else {
-                                                    $content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
-                                            }
-						
-					}
+                        foreach ($rows as $item) {
+                                $content .= "<tr>";
+                                foreach ($item as $key => $value) {
+                                    if($key==='user_dn' && $value != '') {
+                                            $string = explode(',', $value);
+                                            $paquet = substr($string[1],3);
+                                            $section = substr($paquet, 0,-4);
+                                            $section = str_replace("BTS", "", $section);
+                                            $promo = substr($paquet, -4);
+                                            $content .= "<td>".htmlspecialchars($section, ENT_QUOTES, 'UTF-8')."</td>";
+                                            $content .= "<td>".htmlspecialchars($promo, ENT_QUOTES, 'UTF-8')."</td>";
+                                    }
+                                    else {
+                                            $content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
+                                    }
 
-					if($table===$this->tablesGlpi['eleves']){
-						if (in_array($item['id'], $this->ElevesIds)) {
-							if ($this->pdfAuth) $content .= '<td class="check"></td>';
-						} else {
-							if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.$item['id'].'" name="item_'.$item['id'].'" checked /></td>';
-						}
-					}
-					if($table===$this->tablesGlpi['pc']){
-						if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.$item['id'].'" name="item_'.$item['id'].'" checked /></td>';
-					}
+                                }
 
-				$content .= "</tr>";
-			}
-			
-            $html = str_replace('{{PAGETITLE}}', $title, $html);
-            $html = str_replace('{{TITLES}}', $theaders, $html);
-            $html = str_replace('{{CONTENT}}', $content, $html);
+                                if($table===$this->tablesGlpi['eleves']){
+                                        if (in_array($item['id'], $this->ElevesIds)) {
+                                                if ($this->pdfAuth) $content .= '<td class="check"></td>';
+                                        } else {
+                                                if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.$item['id'].'" name="item_'.$item['id'].'" checked /></td>';
+                                        }
+                                }
+                                if($table===$this->tablesGlpi['pc']){
+                                        if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.$item['id'].'" name="item_'.$item['id'].'" checked /></td>';
+                                }
 
+                                $content .= "</tr>";
+                        }
 
-			if($categorie==='pc'){
-				$html = str_replace('{{FORMACTION}}', ' action="listpc"', $html);
-			}
-			elseif($categorie==='eleve'){
-				$html = str_replace('{{FORMACTION}}', ' action="listeleve"', $html);
-			}
-			else{
-				$html = str_replace('{{FORMACTION}}', '', $html);
-			}
-			$html = str_replace('{{buttons}}', '', $html);
-			
+                        $vars = [
+                                'PAGETITLE' => $title,
+                                'TITLES' => $theaders,
+                                'CONTENT' => $content,
+                                'FORMACTION' => '',
+                                'buttons' => '',
+                                'PRINTINPUT' => ''
+                        ];
+                        if($categorie==='pc'){
+                                $vars['FORMACTION'] = ' action="listpc"';
+                        }
+                        elseif($categorie==='eleve'){
+                                $vars['FORMACTION'] = ' action="listeleve"';
+                        }
 
-			return ['CONTENT'=> $html];
-		}
+                        $html = View::render('glpipc/listesGlpi.php', $vars);
+
+                        return ['CONTENT'=> $html];
+                }
 		// BDD
 		
 		/**

--- a/app/controllers/InController.php
+++ b/app/controllers/InController.php
@@ -213,52 +213,29 @@ $this->messagepc .= "<div>".htmlspecialchars($lcd[0]['promo'], ENT_QUOTES, 'UTF-
 		}
 
 		// Afficher la vue login avec les erreurs
-		private function renderView(): string {
-                        $html = file_get_contents(filename: '../app/views/in.php');
-                        $html = str_replace('{{csrf_token}}', htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'), $html);
-                        $messageeleve = "";
+                private function renderView(): string {
+                        $vars = [
+                                'csrf_token' => htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'),
+                                'errors' => '',
+                                'msgpc' => '',
+                                'pcbarrecode' => ''
+                        ];
 
+                        if (!empty($this->messages)) {
+                                foreach ($this->messages as $error) {
+                                        $content = $error['content'];
+                                        $result = $error['result'];
+                                        $vars['errors'] .= '<p class="'.$result.'">' . htmlspecialchars($content, ENT_QUOTES, 'UTF-8') . '</p>';
+                                }
+                        }
 
+                        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                                if ($this->pc) {
+                                        $vars['msgpc'] = $this->messagepc;
+                                        $vars['pcbarrecode'] = htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8');
+                                }
+                        }
 
-			$messages = '';			
-	
-				// Ajouter les erreurs
-				if (!empty($this->messages)) {
-					foreach ($this->messages as $error) {
-						$content = $error['content'];
-						$result = $error['result'];
-						$messages .= '<p class="'.$result.'">' . htmlspecialchars($content, ENT_QUOTES, 'UTF-8') . "</p>";
-					}
-					$html = str_replace('{{errors}}', $messages, $html);
-				}
-				else {
-					$html = str_replace('{{errors}}', '', $html);
-				}
-			
-			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-
-if($this->pc){
-$html = str_replace('{{msgpc}}', $this->messagepc, $html);
-$html = str_replace('{{pcbarrecode}}', htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
-}
-				else {
-					$html = str_replace('{{pcbarrecode}}', '', $html);
-					$html = str_replace('{{msgpc}}', '', $html);
-				}
-
-
-			}
-			else {
-				$html = str_replace('{{msgpc}}', '', $html);
-
-				
-
-
-				// $html = str_replace('{{errors}}', '', $html);
-				$html = str_replace('{{pcbarrecode}}', '', $html);
-			}
-
-
-			return $html;
-		}
+                        return View::render('in.php', $vars);
+                }
 	}

--- a/app/controllers/InterfaceController.php
+++ b/app/controllers/InterfaceController.php
@@ -1,7 +1,9 @@
 <?php
-	namespace app\controllers;
-	
-	class InterfaceController {
+        namespace app\controllers;
+
+        use app\core\View;
+
+        class InterfaceController {
 		private $content = [
 				'TITLE' => "Interface",
 				'CONTENT'   => ''
@@ -16,14 +18,12 @@
 			return $this->content;
 		}
 		
-		private function renderView(){
-			$htmlView = file_get_contents(filename: '../app/views/interface.php');
-				
-			$htmlView = str_replace('{{TITLE}}', $this->content['TITLE'], $htmlView);
-			$htmlView = str_replace('{{CONTENT}}', $this->content['CONTENT'], $htmlView);
+                private function renderView(){
+                        $this->content['CONTENT'] = View::render('interface.php', [
+                                'TITLE' => $this->content['TITLE'],
+                                'CONTENT' => $this->content['CONTENT']
+                        ]);
 
-			$this->content['CONTENT'] = $htmlView;
-
-		}
+                }
 		
     }

--- a/app/controllers/ListingController.php
+++ b/app/controllers/ListingController.php
@@ -1,7 +1,9 @@
 <?php
-	namespace app\controllers;	
+        namespace app\controllers;
 
-	class ListingController {
+        use app\core\View;
+
+        class ListingController {
 		private $CheckDb;
 		private $fpdfPath = '../app/vendor/fpdf/fpdf.php';
 		private $pdf;
@@ -37,55 +39,56 @@
 					$sqlList[] = $value;
 				}
 			}
-			else {
-				$html = file_get_contents('../app/views/listes.php');
-				$titles = [
-					"ID" => 'id',
-					"barrecode" => 'barrecode',
-					"Modèle" => 'model',
-					// "Numéro de Série" => 'serialnum',
-					"État" => 'etat',
-					"Entrée" => 'birth',
-					"Position" => 'position',
-					"Last" => 'lasteleve_id',
-				];
-				$theaders = "<tr>";
-				foreach ($titles as $key => $value) {
-					$theaders .= "<th>".$key."</th>";
-					$sqlList[] = $value;
-				}
-				if ($this->pdfAuth) $theaders .= '<th>Check</th>';
-				$theaders .= "</tr>";
-			}
-			
-			$items = $this->getRowsFrom('pc',implode(",", $sqlList));
+                        else {
+                                $titles = [
+                                        "ID" => 'id',
+                                        "barrecode" => 'barrecode',
+                                        "Modèle" => 'model',
+                                        // "Numéro de Série" => 'serialnum',
+                                        "État" => 'etat',
+                                        "Entrée" => 'birth',
+                                        "Position" => 'position',
+                                        "Last" => 'lasteleve_id',
+                                ];
+                                $theaders = "<tr>";
+                                foreach ($titles as $key => $value) {
+                                        $theaders .= "<th>".$key."</th>";
+                                        $sqlList[] = $value;
+                                }
+                                if ($this->pdfAuth) $theaders .= '<th>Check</th>';
+                                $theaders .= "</tr>";
+                        }
 
-			if($formatPdf){
-				$this->displayPdf($items);
-			}
-			else {
-				$content = '';
-				foreach ($items as $item) {
-						$content .= '<tr id="row_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'">';
-						foreach ($item as $value) {
-							$content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
-						}
-						if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" name="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" checked /></td>';
-					$content .= "</tr>";
-				}
-				
-				$html = str_replace('#PAGETITLE#', 'Liste des Pc', $html);
-				$html = str_replace('{{TITLES}}', $theaders, $html);
-				$html = str_replace('{{CONTENT}}', $content, $html);
-				$html = str_replace('{{FORMACTION}}', $this->pdfAuth?' target="_blank" action="listpc"':'', $html);
-				$html = str_replace('{{buttons}}', '<input type="submit" value="Pdf Barrecode">', $html);
-				$html = str_replace('{{PRINTINPUT}}', '<input type="hidden" name="print" value="print">', $html);
-				
-				return [
-					'CONTENT'=> $html,
-					'TITLE'=> 'Pc list'
-				];
-			}
+                        $items = $this->getRowsFrom('pc',implode(",", $sqlList));
+
+                        if($formatPdf){
+                                $this->displayPdf($items);
+                        }
+                        else {
+                                $content = '';
+                                foreach ($items as $item) {
+                                        $content .= '<tr id="row_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'">';
+                                        foreach ($item as $value) {
+                                                $content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
+                                        }
+                                        if ($this->pdfAuth) $content .= '<td class="check"><input type="checkbox" id="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" name="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" checked /></td>';
+                                        $content .= "</tr>";
+                                }
+
+                                $html = View::render('listes.php', [
+                                        'PAGETITLE' => 'Liste des Pc',
+                                        'TITLES' => $theaders,
+                                        'CONTENT' => $content,
+                                        'FORMACTION' => $this->pdfAuth ? ' target="_blank" action="listpc"' : '',
+                                        'buttons' => '<input type="submit" value="Pdf Barrecode">',
+                                        'PRINTINPUT' => '<input type="hidden" name="print" value="print">'
+                                ]);
+
+                                return [
+                                        'CONTENT'=> $html,
+                                        'TITLE'=> 'Pc list'
+                                ];
+                        }
 
 		}
 		private function displayPdf($items=[]){
@@ -116,101 +119,103 @@
 		/**
 		 * Fonction Lire listEleves
 		*/
-		public function listEleves() {
-			$html = file_get_contents('../app/views/listes.php');
-			// id 	barrecode 	nom 	prenom 	promo 	classe 	birth 	mail 	lastpc_id 	
-			$sqlList = [];
-			$titles = [
-				"ID" => 'id',
-				"barrecode" => 'barrecode',
-				"nom" => 'nom',
-				"prenom" => 'prenom',
-				"classe" => 'classe',
-				"promo" => 'promo',
-				"birth" => 'birth',
-				"glpi_id" => 'glpi_id',
-				// "mail" => 'mail',
-				"lastpc_id" => 'lastpc_id'
-			];
+                public function listEleves() {
+                        // id   barrecode       nom     prenom  promo   classe  birth   mail    lastpc_id
+                        $sqlList = [];
+                        $titles = [
+                                "ID" => 'id',
+                                "barrecode" => 'barrecode',
+                                "nom" => 'nom',
+                                "prenom" => 'prenom',
+                                "classe" => 'classe',
+                                "promo" => 'promo',
+                                "birth" => 'birth',
+                                "glpi_id" => 'glpi_id',
+                                // "mail" => 'mail',
+                                "lastpc_id" => 'lastpc_id'
+                        ];
 
-			$theaders = "<tr>";
-			$theaders .= "<th>Check</th>";
-			foreach ($titles as $key => $value) {
-				$theaders .= "<th>".$key."</th>";
-				$sqlList[] = $value;
-			}
-			$theaders .= "<th>Action</th>";
-			$theaders .= "</tr>";
+                        $theaders = "<tr>";
+                        $theaders .= "<th>Check</th>";
+                        foreach ($titles as $key => $value) {
+                                $theaders .= "<th>".$key."</th>";
+                                $sqlList[] = $value;
+                        }
+                        $theaders .= "<th>Action</th>";
+                        $theaders .= "</tr>";
 
-			$items = $this->getRowsFrom('eleves',implode(",", $sqlList));
+                        $items = $this->getRowsFrom('eleves',implode(",", $sqlList));
 
-			$content = '';
-			foreach ($items as $item) {
-				$content .= "<tr>";
-				$content .= '<td><input type="checkbox" id="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" name="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" /></td>';
-				foreach ($item as $value) {
-					$content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
-				}
-				$content .= '<td><a href="/eleve?num='.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'">ref: '.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'</a></td>';
-				$content .= "</tr>";
-			}
-			
-            $html = str_replace('#PAGETITLE#', 'Liste des Élèves', $html);
-            $html = str_replace('{{TITLES}}', $theaders, $html);
-            $html = str_replace('{{CONTENT}}', $content, $html);
-			$html = str_replace('{{FORMACTION}}', $this->pdfAuth?' target="_blank" action="listeleve"':'', $html);
-			$html = str_replace('{{buttons}}', '', $html);
-			$html = str_replace('{{PRINTINPUT}}', '', $html);
-			
-			return [
-				'CONTENT'=> $html,
-				'TITLE'=> 'Élèves list'
-			];
-		}
+                        $content = '';
+                        foreach ($items as $item) {
+                                $content .= "<tr>";
+                                $content .= '<td><input type="checkbox" id="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" name="item_'.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'" /></td>';
+                                foreach ($item as $value) {
+                                        $content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
+                                }
+                                $content .= '<td><a href="/eleve?num='.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'">ref: '.htmlspecialchars($item['id'], ENT_QUOTES, 'UTF-8').'</a></td>';
+                                $content .= "</tr>";
+                        }
+
+                        $html = View::render('listes.php', [
+                                'PAGETITLE' => 'Liste des Élèves',
+                                'TITLES' => $theaders,
+                                'CONTENT' => $content,
+                                'FORMACTION' => $this->pdfAuth ? ' target="_blank" action="listeleve"' : '',
+                                'buttons' => '',
+                                'PRINTINPUT' => ''
+                        ]);
+
+                        return [
+                                'CONTENT'=> $html,
+                                'TITLE'=> 'Élèves list'
+                        ];
+                }
 
 		/**
 		 * Fonction Lire listTimeline
 		*/
-		public function listTimeline() {
-			$html = file_get_contents('../app/views/listes.php');
-			$content = '';
-			$sqlList = [];
-			$titles = [
-				"ID" => 'id',
-				"idpc" => 'idpc',
-				"ideleves" => 'ideleves',
-				"typeaction" => 'typeaction',
-				"Date" => 'birth',
-			];
-			$theaders = "<tr>";
-			foreach ($titles as $key => $value) {
-				$theaders .= "<th>".$key."</th>";
-				$sqlList[] = $value;
-			}
-			$theaders .= "</tr>";
+                public function listTimeline() {
+                        $content = '';
+                        $sqlList = [];
+                        $titles = [
+                                "ID" => 'id',
+                                "idpc" => 'idpc',
+                                "ideleves" => 'ideleves',
+                                "typeaction" => 'typeaction',
+                                "Date" => 'birth',
+                        ];
+                        $theaders = "<tr>";
+                        foreach ($titles as $key => $value) {
+                                $theaders .= "<th>".$key."</th>";
+                                $sqlList[] = $value;
+                        }
+                        $theaders .= "</tr>";
 
-			$items = $this->getRowsFrom('timeline',implode(",", $sqlList));
+                        $items = $this->getRowsFrom('timeline',implode(",", $sqlList));
 
-			foreach ($items as $item) {
-					$content .= "<tr>";
-					foreach ($item as $value) {
-						$content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class="null">null</em>')."</td>";
-					}
-				$content .= "</tr>";
-			}
-			
-            $html = str_replace('#PAGETITLE#', 'Timeline', $html);
-            $html = str_replace('{{TITLES}}', $theaders, $html);
-            $html = str_replace('{{CONTENT}}', $content, $html);
-			$html = str_replace('{{FORMACTION}}', $this->pdfAuth?' target="_blank" action="timeline"':'', $html);
-			$html = str_replace('{{buttons}}', '', $html);
-			$html = str_replace('{{PRINTINPUT}}', '', $html);
+                        foreach ($items as $item) {
+                                $content .= "<tr>";
+                                foreach ($item as $value) {
+                                        $content .= "<td>".($value!==null ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8') : '<em class=\"null\">null</em>')."</td>";
+                                }
+                                $content .= "</tr>";
+                        }
 
-			return [
-				'CONTENT'=> $html,
-				'TITLE'=> 'Timeline'
-			];
-		}
+                        $html = View::render('listes.php', [
+                                'PAGETITLE' => 'Timeline',
+                                'TITLES' => $theaders,
+                                'CONTENT' => $content,
+                                'FORMACTION' => $this->pdfAuth ? ' target="_blank" action="timeline"' : '',
+                                'buttons' => '',
+                                'PRINTINPUT' => ''
+                        ]);
+
+                        return [
+                                'CONTENT'=> $html,
+                                'TITLE'=> 'Timeline'
+                        ];
+                }
 
 		// BDD
 		

--- a/app/controllers/LoginController.php
+++ b/app/controllers/LoginController.php
@@ -1,7 +1,9 @@
 <?php
-	namespace app\controllers;
-	
-	class LoginController {
+        namespace app\controllers;
+
+        use app\core\View;
+
+        class LoginController {
 		private $pdo;
 		private $CheckDb;
 	
@@ -179,31 +181,28 @@
 		}
 
 		// Afficher la vue login avec les erreurs
-		private function renderView($errors = []) {
-			$html = file_get_contents('../app/views/login.php');
-			$htmlform = file_get_contents('../app/views/login/loginForm.php');
-	
-			// Ajouter les erreurs
-			$errorHtml = '';
-			
-			if (!empty($errors)) {
-				foreach ($errors as $error) {
-					$errorHtml .= "<p class='error'>" . $error . "</p>";
-				}
-			}
-	
-			$html = str_replace('{{errors}}', $errorHtml, $html);
-			if($this->pdo){
-				$html = str_replace('{{loginform}}', $htmlform, $html);
-			}
-			else {
-				$html = str_replace('{{loginform}}', '', $html);
-			}
-			return [
-				'CONTENT'=> $html,
-				'TITLE'=> 'Page Login',
-			];
-		}
+                private function renderView($errors = []) {
+                        $vars = [
+                                'errors' => '',
+                                'loginform' => ''
+                        ];
+
+                        if (!empty($errors)) {
+                                foreach ($errors as $error) {
+                                        $vars['errors'] .= "<p class='error'>" . $error . "</p>";
+                                }
+                        }
+
+                        if ($this->pdo) {
+                                $vars['loginform'] = View::render('login/loginForm.php');
+                        }
+
+                        $html = View::render('login.php', $vars);
+                        return [
+                                'CONTENT'=> $html,
+                                'TITLE'=> 'Page Login',
+                        ];
+                }
 		
 		public function logout()
 		{

--- a/app/controllers/NotFoundController.php
+++ b/app/controllers/NotFoundController.php
@@ -1,8 +1,10 @@
 <?php
 
-	namespace app\controllers;
+        namespace app\controllers;
 
-	class NotFoundController
+        use app\core\View;
+
+        class NotFoundController
 	{
 
 		private $boule = '';
@@ -25,13 +27,10 @@
 			return $this->content;
 		}
 		// Afficher la vue login avec les erreurs
-		private function renderView(){
-			$htmlView = file_get_contents(filename: '../app/views/notfound.php');
-				
-			$htmlView = str_replace('{{TITLE}}', $this->content['TITLE'], $htmlView);
-			$htmlView = str_replace('{{CONTENT}}', $this->content['CONTENT'], $htmlView);
-
-			$this->content['CONTENT'] = $htmlView;
-
-		}
-	}
+                private function renderView(){
+                        $this->content['CONTENT'] = View::render('notfound.php', [
+                                'TITLE' => $this->content['TITLE'],
+                                'CONTENT' => $this->content['CONTENT']
+                        ]);
+                }
+        }

--- a/app/controllers/OutController.php
+++ b/app/controllers/OutController.php
@@ -127,58 +127,34 @@
 		}
 	
 		// Afficher la vue login avec les erreurs
-		private function renderView(): string {
-                        $html = file_get_contents(filename: '../app/views/out.php');
-                        $html = str_replace('{{csrf_token}}', htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'), $html);
-                        $messageeleve = "";
-			$messagepc = "";
-			$messages = '';			
-	
-			
-			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-if($this->eleve){
-$messageeleve .= htmlspecialchars($this->eleve['barrecode'], ENT_QUOTES, 'UTF-8');
-$html = str_replace('{{msgeleve}}', htmlspecialchars($this->eleve['prenom'], ENT_QUOTES, 'UTF-8')." ".htmlspecialchars($this->eleve['nom'], ENT_QUOTES, 'UTF-8')."<br>", $html);
-$html = str_replace('{{elevebarrecode}}', htmlspecialchars($this->eleve['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
-}
-				else {
-					$html = str_replace('{{elevebarrecode}}', '', $html);
-					$html = str_replace('{{msgeleve}}', '', $html);
-				}
+                private function renderView(): string {
+                        $vars = [
+                                'csrf_token' => htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'),
+                                'msgeleve' => '',
+                                'msgpc' => '',
+                                'errors' => '',
+                                'pcbarrecode' => '',
+                                'elevebarrecode' => ''
+                        ];
 
-if($this->pc){
-$messagepc .= htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8');
-$html = str_replace('{{msgpc}}', htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
-$html = str_replace('{{pcbarrecode}}', htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8'), $html);
-}
-				else {
-					$html = str_replace('{{pcbarrecode}}', '', $html);
-					$html = str_replace('{{msgpc}}', '', $html);
-				}
+                        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                                if ($this->eleve) {
+                                        $vars['msgeleve'] = htmlspecialchars($this->eleve['prenom'], ENT_QUOTES, 'UTF-8') . " " . htmlspecialchars($this->eleve['nom'], ENT_QUOTES, 'UTF-8') . "<br>";
+                                        $vars['elevebarrecode'] = htmlspecialchars($this->eleve['barrecode'], ENT_QUOTES, 'UTF-8');
+                                }
+                                if ($this->pc) {
+                                        $vars['msgpc'] = htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8');
+                                        $vars['pcbarrecode'] = htmlspecialchars($this->pc['barrecode'], ENT_QUOTES, 'UTF-8');
+                                }
+                                if (!empty($this->messages)) {
+                                        foreach ($this->messages as $error) {
+                                                $content = $error['content'];
+                                                $result = $error['result'];
+                                                $vars['errors'] .= '<p class="'.$result.'">' . htmlspecialchars($content, ENT_QUOTES, 'UTF-8') . '</p>';
+                                        }
+                                }
+                        }
 
-
-				// Ajouter les erreurs
-				if (!empty($this->messages)) {
-					foreach ($this->messages as $error) {
-						$content = $error['content'];
-						$result = $error['result'];
-						$messages .= '<p class="'.$result.'">' . htmlspecialchars($content, ENT_QUOTES, 'UTF-8') . "</p>";
-					}
-					$html = str_replace('{{errors}}', $messages, $html);
-				}
-				else {
-					$html = str_replace('{{errors}}', '', $html);
-				}
-			}
-			else {
-				$html = str_replace('{{msgpc}}', '', $html);
-				$html = str_replace('{{msgeleve}}', '', $html);
-				$html = str_replace('{{errors}}', '', $html);
-				$html = str_replace('{{pcbarrecode}}', '', $html);
-				$html = str_replace('{{elevebarrecode}}', '', $html);
-			}
-
-
-			return $html;
-		}
+                        return View::render('out.php', $vars);
+                }
 	}

--- a/app/controllers/ProfileController.php
+++ b/app/controllers/ProfileController.php
@@ -1,6 +1,8 @@
 <?php
         namespace app\controllers;
 
+        use app\core\View;
+
         class ProfileController
         {
                 private $view = '';
@@ -16,7 +18,6 @@
                         if($CheckDb){
                                 $this->CheckDb = $CheckDb;
                         }
-                        $this->view = file_get_contents('../app/views/profile.php');
                 }
 
                 public function showProfile()
@@ -26,7 +27,6 @@
                                 header('Location: /login');
                         } else {
 
-                                $content = str_replace("{{TITLE}}",$this->contents['TITLE'],$this->view);
                                 $profileHtml = 'une erreur sans doute ?';
                                 $row = $this->getProfilRow();
                                 if ($row && count($row) > 0){
@@ -43,11 +43,12 @@
                                 }
 
 
-                                $content = str_replace("{{CONTENT}}",$profileHtml, $content);
+                                $html = View::render('profile.php', [
+                                        'TITLE' => $this->contents['TITLE'],
+                                        'CONTENT' => $profileHtml
+                                ]);
 
-
-
-                                $this->contents['CONTENT'] = $content;
+                                $this->contents['CONTENT'] = $html;
                                 return $this->contents;
                         }
                 }

--- a/app/controllers/ThreeController.php
+++ b/app/controllers/ThreeController.php
@@ -1,7 +1,9 @@
 <?php
-	namespace app\controllers;
-	
-	class ThreeController {
+        namespace app\controllers;
+
+        use app\core\View;
+
+        class ThreeController {
 		private $CheckDb;
 		private $pdo;
 		private $pcs = [];
@@ -40,17 +42,13 @@
 			if($this->timeline && count($this->timeline)>0) $this->timelineJson = json_encode($this->timeline);
 		}
 		
-		private function renderView(){
-			$htmlView = file_get_contents(filename: '../app/views/three.php');
-			
-			// $htmlView = str_replace('{{TITLE}}', $this->content['TITLE'], $htmlView);
-			// $htmlView = str_replace('{{CONTENT}}', $this->content['CONTENT'], $htmlView);
-$htmlView = str_replace('{{pcsJson}}', htmlspecialchars($this->pcsJson, ENT_QUOTES, 'UTF-8'), $htmlView);
-$htmlView = str_replace('{{timelineJson}}', htmlspecialchars($this->timelineJson, ENT_QUOTES, 'UTF-8'), $htmlView);
+                private function renderView(){
+                        $this->content['CONTENT'] = View::render('three.php', [
+                                'pcsJson' => htmlspecialchars($this->pcsJson, ENT_QUOTES, 'UTF-8'),
+                                'timelineJson' => htmlspecialchars($this->timelineJson, ENT_QUOTES, 'UTF-8')
+                        ]);
 
-			$this->content['CONTENT'] = $htmlView;
-
-		}
+                }
 		// BDD
 		
 		/**

--- a/app/controllers/exampleController.php
+++ b/app/controllers/exampleController.php
@@ -1,7 +1,9 @@
 <?php
-	namespace app\controllers;
-	
-	class ExampleController {
+        namespace app\controllers;
+
+        use app\core\View;
+
+        class ExampleController {
 		private $menus = [];
 		private $content = [
 				'TITLE' => "example",
@@ -33,14 +35,12 @@
 			die();
 		}
 		
-		private function renderView(){
-			$htmlView = file_get_contents(filename: '../app/views/example.php');		
-			$htmlView = str_replace('{{TITLE}}', $this->content['TITLE'], $htmlView);
-			// $htmlView = str_replace('{{CONTENT}}', $this->content['CONTENT'], $htmlView);
+                private function renderView(){
+                        $this->content['CONTENT'] = View::render('example.php', [
+                                'TITLE' => $this->content['TITLE']
+                        ]);
 
-			$this->content['CONTENT'] = $htmlView;
-
-		}
+                }
 
 
 		// Gérer le traitement de connexion

--- a/app/core/View.php
+++ b/app/core/View.php
@@ -1,0 +1,28 @@
+<?php
+namespace app\core;
+
+class View
+{
+    /**
+     * Render a template from app/views
+     *
+     * @param string $template path relative to app/views
+     * @param array $vars variables to replace in template
+     * @return string
+     */
+    public static function render(string $template, array $vars = []): string
+    {
+        $path = __DIR__ . '/../views/' . $template;
+        if (!is_file($path)) {
+            return '';
+        }
+        $content = file_get_contents($path);
+        foreach ($vars as $key => $value) {
+            $value = (string) $value;
+            $content = str_replace('{{' . $key . '}}', $value, $content);
+            $content = str_replace('#' . $key . '#', $value, $content);
+            $content = str_replace('#' . strtoupper($key) . '#', $value, $content);
+        }
+        return $content;
+    }
+}

--- a/app/core/frontConstructor.php
+++ b/app/core/frontConstructor.php
@@ -12,11 +12,11 @@ class FrontConstructor
 
 	public function __construct($Console) {
 
-		$this->Navigation = new Navigation();
-		$this->Navigation2 = new Navigation2();
-		$this->Console = $Console;
-		$this->pageToDisplay = file_get_contents(filename: '../app/views/front.php');
-	}
+                $this->Navigation = new Navigation();
+                $this->Navigation2 = new Navigation2();
+                $this->Console = $Console;
+                $this->pageToDisplay = View::render('front.php');
+        }
 
 	public function addContent(): void
 	{

--- a/app/core/router.php
+++ b/app/core/router.php
@@ -59,10 +59,10 @@ class Router
         $this->routes[$route] = $action;
     }
 
-	public function setdefaultPage()
-	{
-		$this->defaultPage = file_get_contents('../app/views/front.php');
-	}
+        public function setdefaultPage()
+        {
+                $this->defaultPage = View::render('front.php');
+        }
 
 	public function display()
 	{


### PR DESCRIPTION
## Summary
- add core View utility to load templates with variable replacement
- migrate controllers to use View::render for consistent rendering
- refactor router and front constructor to rely on View

## Testing
- `php -l app/controllers/LoginController.php app/controllers/OutController.php app/controllers/ListingController.php app/controllers/InController.php app/controllers/ProfileController.php app/controllers/NotFoundController.php app/controllers/exampleController.php app/controllers/InterfaceController.php app/controllers/ThreeController.php app/controllers/GlpiController.php app/core/frontConstructor.php app/core/router.php app/core/View.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d988c5b48329aac8cfb6b77f4d10