### PR TITLE
Improve Three page JSON handling

### DIFF
--- a/app/controllers/ThreeController.php
+++ b/app/controllers/ThreeController.php
@@ -33,22 +33,32 @@
 			return $this->content;
 		}
 		
-		private function setPcsJson(){
-			$this->pcs = $this->list('pc','*');
-			if($this->pcs && count($this->pcs)>0) $this->pcsJson = json_encode($this->pcs);
-		}
-		private function setTimelineJson(){
-			$this->timeline = $this->list('timeline','*');
-			if($this->timeline && count($this->timeline)>0) $this->timelineJson = json_encode($this->timeline);
-		}
-		
-                private function renderView(){
-                        $this->content['CONTENT'] = View::render('three.php', [
-                                'pcsJson' => htmlspecialchars($this->pcsJson, ENT_QUOTES, 'UTF-8'),
-                                'timelineJson' => htmlspecialchars($this->timelineJson, ENT_QUOTES, 'UTF-8')
-                        ]);
+               private function setPcsJson(){
+                       $this->pcs = $this->list('pc','*');
+                       if($this->pcs && count($this->pcs)>0) {
+                               $this->pcsJson = json_encode(
+                                       $this->pcs,
+                                       JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+                               );
+                       }
+               }
+               private function setTimelineJson(){
+                       $this->timeline = $this->list('timeline','*');
+                       if($this->timeline && count($this->timeline)>0) {
+                               $this->timelineJson = json_encode(
+                                       $this->timeline,
+                                       JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+                               );
+                       }
+               }
 
-                }
+               private function renderView(){
+                       $this->content['CONTENT'] = View::render('three.php', [
+                               'pcsJson' => $this->pcsJson,
+                               'timelineJson' => $this->timelineJson
+                       ]);
+
+               }
 		// BDD
 		
 		/**

--- a/app/views/three.php
+++ b/app/views/three.php
@@ -6,9 +6,9 @@
 		}
 	}
 </script>
-<script>	
-	const pcs = {{pcsJson}}; 
-	const timeline = {{timelineJson}}; 
-	const eleves = {}; 
+<script>
+        const pcs = JSON.parse('{{pcsJson}}');
+        const timeline = JSON.parse('{{timelineJson}}');
+        const eleves = {};
 </script>
 <script defer type="module" src="./js/three.js"></script>

--- a/public/js/three.js
+++ b/public/js/three.js
@@ -148,11 +148,15 @@ function getTextMesh(message) {
 }
 //------------------------------------------
 function addTimeline(){
+    if (!Array.isArray(timeline)) {
+        console.warn('timeline is not an array');
+        return;
+    }
     // La timeline
     let size = {x: 0.9,y: 0.9,z: 0.9};
     let gap = {x: 0.1};
     let max = 10;
-    let length = timeline.length > max ? max : pcs.length;
+    let length = timeline.length > max ? max : timeline.length;
     let start = 0 - (Math.floor(length/2) * size.x) - (Math.floor(length/2) * gap.x )
     let pos = {x: start, y: size.z / 2 , z: 2};
     let count = 0;
@@ -180,6 +184,10 @@ function addTimeline(){
     });
 }
 function addPcs(){
+    if (!Array.isArray(pcs)) {
+        console.warn('pcs is not an array');
+        return;
+    }
     let size = {x: 0.9,y: 0.9,z: 0.9};
     let gap = {x: 0.1};
     let start = 0 - (Math.round(Math.sqrt(pcs.length)) * (size.x + gap.x ))


### PR DESCRIPTION
## Summary
- Encode controller data with safe JSON options and remove redundant HTML escaping
- Parse JSON in the Three view to prevent script injection
- Guard against non-array data before iterating over pcs or timeline

## Testing
- `php -l app/controllers/ThreeController.php`
- `php -l app/views/three.php`
- `node --check public/js/three.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ef61706c8329aba39e432afe42d3